### PR TITLE
Add tempest-k8s into openstack terraform plan

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -866,3 +866,63 @@ resource "juju_integration" "ldap-to-keystone" {
     endpoint = "domain-config"
   }
 }
+
+resource "juju_application" "tempest" {
+  count = var.enable-validation ? 1 : 0
+  name  = "tempest"
+  model = juju_model.sunbeam.name
+
+  charm {
+    name     = "tempest-k8s"
+    channel  = var.tempest-channel == null ? var.openstack-channel : var.tempest-channel
+    revision = var.tempest-revision
+  }
+
+  units  = 1
+  config = var.tempest-config
+}
+
+resource "juju_integration" "tempest-to-keystone" {
+  count = var.enable-validation ? 1 : 0
+  model = juju_model.sunbeam.name
+
+  application {
+    name     = module.keystone.name
+    endpoint = "identity-ops"
+  }
+
+  application {
+    name     = juju_application.tempest[count.index].name
+    endpoint = "identity-ops"
+  }
+}
+
+resource "juju_integration" "tempest-to-grafana-agent-k8s-loki" {
+  count = (var.enable-validation && var.logging-provider != "") ? 1 : 0
+  model = juju_model.sunbeam.name
+
+  application {
+    name     = juju_application.tempest[count.index].name
+    endpoint = "logging"
+  }
+
+  application {
+    name     = var.grafana-agent-k8s-name
+    endpoint = var.logging-provider
+  }
+}
+
+resource "juju_integration" "tempest-to-grafana-agent-k8s-grafana" {
+  count = (var.enable-validation && var.grafana-dashboards-consumer != "") ? 1 : 0
+  model = juju_model.sunbeam.name
+
+  application {
+    name     = juju_application.tempest[count.index].name
+    endpoint = "grafana-dashboard"
+  }
+
+  application {
+    name     = var.grafana-agent-k8s-name
+    endpoint = var.grafana-dashboards-consumer
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -565,7 +565,7 @@ resource "juju_application" "openstack-exporter" {
   charm {
     name     = "openstack-exporter-k8s"
     channel  = var.openstack-exporter-channel == null ? var.openstack-channel : var.openstack-exporter-channel
-    revision = var.openstack-exporter-channel
+    revision = var.openstack-exporter-revision
   }
 
   config = var.openstack-exporter-config

--- a/variables.tf
+++ b/variables.tf
@@ -636,3 +636,51 @@ variable "horizon-plugins" {
   type        = list(string)
   default     = []
 }
+
+variable "enable-validation" {
+  description = "Enable Tempest deployment"
+  type        = bool
+  default     = false
+}
+
+variable "tempest-channel" {
+  description = "Operator channel for Tempest deployment"
+  type        = string
+  default     = null
+}
+
+variable "tempest-revision" {
+  description = "Operator channel revision for Tempest deployment"
+  type        = number
+  default     = null
+}
+
+variable "tempest-config" {
+  description = "Operator config for Tempest deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "grafana-agent-k8s-name" {
+  description = "Operator name for Grafana Agent K8s deployment"
+  type        = string
+  default     = "grafana-agent-k8s"
+}
+
+variable "metrics-endpoint" {
+  description = "Endpoint name for grafana-agent-k8s:metric_endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "logging-provider" {
+  description = "Endpoint name for grafana-agent-k8s:logging-provider"
+  type        = string
+  default     = ""
+}
+
+variable "grafana-dashboards-consumer" {
+  description = "Endpoint name for grafana-agent-k8s:grafana-dashboards-consumer"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
This PR adds tempest-k8s into openstack terraform plan.

- The tempest-k8s will only be deployed if the validation plugin is enabled
- The integration to grafana-agent-k8s (loki and grafana) will only be established if the observability plugin is enabled

Relates to:  https://github.com/agileshaw/snap-openstack/pull/2